### PR TITLE
Send PIX ID, return PIX UUID in case of failure or success

### DIFF
--- a/santander_sdk/__init__.py
+++ b/santander_sdk/__init__.py
@@ -22,7 +22,6 @@ from santander_sdk.payment_receipts import (
 )
 from santander_sdk.api_client.exceptions import (
     SantanderRequestError,
-    SantanderValueError,
     SantanderError,
 )
 
@@ -48,6 +47,5 @@ __all__ = [
     "ReceiptCreationHistoryResponse",
     # Comom exceptions
     "SantanderRequestError",
-    "SantanderValueError",
     "SantanderError",
 ]

--- a/santander_sdk/api_client/exceptions.py
+++ b/santander_sdk/api_client/exceptions.py
@@ -30,14 +30,6 @@ class SantanderClientError(SantanderError):
         return f"Santander client error: {super().__str__()}"
 
 
-class SantanderValueError(SantanderError, ValueError):
-    def __init__(self, message):
-        super().__init__(message)
-
-    def __str__(self):
-        return f"Internal data error: {super().__str__()}"
-
-
 class SantanderRejectedError(SantanderError):
     def __init__(self, message):
         super().__init__(message)

--- a/santander_sdk/api_client/helpers.py
+++ b/santander_sdk/api_client/helpers.py
@@ -7,10 +7,7 @@ import re
 import requests
 import pathlib
 
-from santander_sdk.api_client.exceptions import (
-    SantanderRequestError,
-    SantanderValueError,
-)
+from santander_sdk.api_client.exceptions import SantanderRequestError
 
 logger = logging.getLogger("santanderLogger")
 
@@ -53,7 +50,7 @@ def get_pix_key_type(chave: str) -> DictCodeTypes:
     elif len(only_numbers(chave)) == 13 and chave.startswith("+"):
         return "CELULAR"
     else:
-        raise SantanderValueError(f"Chave Pix em formato inválido: {chave}")
+        raise ValueError(f"Chave Pix em formato inválido: {chave}")
 
 
 def try_parse_response_to_json(response) -> dict | None:
@@ -149,7 +146,7 @@ def document_type(document_number: str) -> Literal["CPF", "CNPJ"]:
         return "CPF"
     if len(document_number) == 14:
         return "CNPJ"
-    raise SantanderValueError('Unknown document type "{document_number}"')
+    raise ValueError('Unknown document type "{document_number}"')
 
 
 def get_content_from_url(url: str) -> bytes:

--- a/santander_sdk/payment_receipts.py
+++ b/santander_sdk/payment_receipts.py
@@ -46,10 +46,7 @@ import logging
 from time import sleep
 from typing import Generator, List, cast
 from santander_sdk.api_client.client import SantanderApiClient
-from santander_sdk.api_client.exceptions import (
-    SantanderRequestError,
-    SantanderValueError,
-)
+from santander_sdk.api_client.exceptions import SantanderRequestError
 from santander_sdk.typing.receipts_types import (
     ALREADY_REQUESTED_RECEIPT,
     ReceiptInfoResponse,
@@ -105,7 +102,7 @@ def create_receipt(
     You need the request.requestId to get the receipt when it's ready.
     """
     if not payment_id:
-        raise SantanderValueError("payment_id is required to create a receipt request.")
+        raise ValueError("payment_id is required to create a receipt request.")
     endpoint = f"{RECEIPTS_ENDPOINT}/{payment_id}/file_requests"
     try:
         response = cast(ReceiptInfoResponse, client.post(endpoint, None))
@@ -128,7 +125,7 @@ def get_receipt(
 ) -> ReceiptInfoResult:
     """Get the payment receipt information to download the file."""
     if not (payment_id and receipt_request_id):
-        raise SantanderValueError("payment_id and receipt_request are required")
+        raise ValueError("payment_id and receipt_request are required")
     endpoint = f"{RECEIPTS_ENDPOINT}/{payment_id}/file_requests/{receipt_request_id}"
     response = cast(ReceiptInfoResponse, client.get(endpoint))
     return _receipt_result(response, payment_id)

--- a/santander_sdk/pix.py
+++ b/santander_sdk/pix.py
@@ -1,12 +1,10 @@
 from decimal import Decimal as D
 import logging
+import uuid
 from typing import cast
 
 from santander_sdk.api_client.client import SantanderApiClient
-from santander_sdk.api_client.exceptions import (
-    SantanderClientError,
-    SantanderValueError,
-)
+from santander_sdk.api_client.exceptions import SantanderClientError
 
 from santander_sdk.api_client.helpers import (
     get_pix_key_type,
@@ -29,14 +27,17 @@ def transfer_pix(
     value: D,
     description: str,
     tags: list[str] = [],
+    id: uuid.UUID | str | None = None,
 ) -> TransferPixResult:
+    transfer_flow = SantanderPaymentFlow(client, PIX_ENDPOINT, logger)
+
     try:
         if value is None or value <= 0:
-            raise SantanderValueError(f"Invalid value for PIX transfer: {value}")
+            raise ValueError(f"Invalid value for PIX transfer: {value}")
 
-        transfer_flow = SantanderPaymentFlow(client, PIX_ENDPOINT, logger)
-
-        create_pix_dict = _generate_create_pix_dict(pix_key, value, description, tags)
+        create_pix_dict = _generate_create_pix_dict(
+            pix_key, value, description, tags, id
+        )
         create_pix_response = transfer_flow.create_payment(create_pix_dict)
         if not create_pix_response.get("id"):
             raise SantanderClientError("Payment ID was not returned on creation")
@@ -51,18 +52,28 @@ def transfer_pix(
         confirm_response = transfer_flow.confirm_payment(
             payment_data, create_pix_response.get("id")
         )
-        return {"success": True, "data": confirm_response, "error": ""}
+        return {
+            "success": True,
+            "request_id": transfer_flow.request_id,
+            "data": confirm_response,
+            "error": "",
+        }
     except Exception as e:
         error_message = str(e)
         logger.error(error_message)
-        return {"success": False, "error": error_message, "data": None}
+        return {
+            "success": False,
+            "request_id": transfer_flow.request_id,
+            "error": error_message,
+            "data": None,
+        }
 
 
 def get_transfer(
     client: SantanderApiClient, pix_payment_id: str
 ) -> SantanderPixResponse:
     if not pix_payment_id:
-        raise SantanderValueError("pix_payment_id not provided")
+        raise ValueError("pix_payment_id not provided")
     response = client.get(f"{PIX_ENDPOINT}/{pix_payment_id}")
     return cast(SantanderPixResponse, response)
 
@@ -72,12 +83,17 @@ def _generate_create_pix_dict(
     value: D,
     description: str,
     tags: list = [],
+    id: uuid.UUID | None = None,
 ) -> dict:
     data = {
         "tags": tags,
         "paymentValue": truncate_value(value),
         "remittanceInformation": description,
     }
+
+    if id:
+        data["id"] = str(id)
+
     if isinstance(pix_key, str):
         pix_type = get_pix_key_type(pix_key)
         data.update({"dictCode": pix_key, "dictCodeType": pix_type})
@@ -86,10 +102,10 @@ def _generate_create_pix_dict(
     if isinstance(pix_key, dict):
         beneficiary = cast(dict, pix_key.copy())
         if beneficiary.get("bankCode") is None and beneficiary.get("ispb") is None:
-            raise SantanderValueError("Either 'bankCode' or 'ispb' must be provided")
+            raise ValueError("Either 'bankCode' or 'ispb' must be provided")
         if beneficiary.get("bankCode") and beneficiary.get("ispb"):
             beneficiary.pop("ispb")
         data.update({"beneficiary": beneficiary})
     else:
-        raise SantanderValueError("PIX key or Beneficiary not provided")
+        raise ValueError("PIX key or Beneficiary not provided")
     return data

--- a/santander_sdk/types.py
+++ b/santander_sdk/types.py
@@ -164,5 +164,6 @@ SantanderPixResponse = SantanderTransferResponse | SantanderAPIErrorResponse
 
 class TransferPixResult(TypedDict):
     success: bool
+    request_id: str | None
     data: SantanderPixResponse | None
     error: str

--- a/tests/test_helpers_unit.py
+++ b/tests/test_helpers_unit.py
@@ -11,10 +11,7 @@ from santander_sdk.api_client.helpers import (
     truncate_value,
     get_pix_key_type,
 )
-from santander_sdk.api_client.exceptions import (
-    SantanderRequestError,
-    SantanderValueError,
-)
+from santander_sdk.api_client.exceptions import SantanderRequestError
 
 
 def test_truncate_value():
@@ -34,10 +31,10 @@ def test_get_pix_key_type():
 
 
 def test_get_pix_key_type_invalid():
-    with pytest.raises(SantanderValueError):
+    with pytest.raises(ValueError):
         get_pix_key_type("234567890abcdef1234567890abcdef")
 
-    with pytest.raises(SantanderValueError):
+    with pytest.raises(ValueError):
         get_pix_key_type("55 34 12345678")
 
 

--- a/tests/test_pix_integration.py
+++ b/tests/test_pix_integration.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 import pytest
 from decimal import Decimal
 
@@ -33,7 +34,7 @@ def mock_api(mocker, responses: RequestsMock):
 
 
 def test_transfer_pix_payment_success(mock_api, client_instance):
-    pix_id = "12345"
+    pix_id = "b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e"
     value = Decimal("100.00")
     description = "Pagamento Teste"
     pix_key = "12345678909"
@@ -59,7 +60,7 @@ def test_transfer_pix_payment_success(mock_api, client_instance):
             "deductedValue": "0.00",
             "dictCode": "12345678909",
             "dictCodeType": "CPF",
-            "id": "12345",
+            "id": "b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e",
             "nominalValue": "100.00",
             "obs": "payment mockado",
             "payer": {
@@ -69,7 +70,7 @@ def test_transfer_pix_payment_success(mock_api, client_instance):
             },
             "paymentValue": "100.00",
             "remittanceInformation": "informação da transferência",
-            "status": OrderStatus.PAYED,
+            "status": "PAYED",
             "tags": [],
             "totalValue": "100.00",
             "transaction": {
@@ -81,6 +82,7 @@ def test_transfer_pix_payment_success(mock_api, client_instance):
             "workspaceId": "3870ba5d-d58e-4182-992f-454e5d0e08e2",
         },
         "success": True,
+        "request_id": "b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e",
         "error": "",
     }
 
@@ -109,7 +111,7 @@ def test_transfer_pix_payment_success(mock_api, client_instance):
     }
     assert (
         confirm_payment_request_url
-        == "https://trust-sandbox.api.santander.com.br/management_payments_partners/v1/workspaces/8e33d56c-204f-461e-aebe-08baaab6479e/pix_payments/12345"
+        == "https://trust-sandbox.api.santander.com.br/management_payments_partners/v1/workspaces/8e33d56c-204f-461e-aebe-08baaab6479e/pix_payments/b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e"
     )
 
 
@@ -132,6 +134,7 @@ def test_transfer_pix_payment_timeout_create(
     assert transfer_result == {
         "success": False,
         "error": "Status update timeout after several attempts: Santander - Status update attempt limit reached",
+        "request_id": "12345",
         "data": None,
     }
     assert mock_create.call_count == 1
@@ -190,6 +193,7 @@ def test_transfer_pix_payment_timeout_before_authorize(
             "workspaceId": "3870ba5d-d58e-4182-992f-454e5d0e08e2",
         },
         "error": "",
+        "request_id": "QAS47FASF5646",
     }
     assert mock_create.call_count == 1
     assert mock_confirm.call_count == 1
@@ -212,6 +216,7 @@ def test_transfer_pix_payment_rejected_on_create(
     assert transfer_result == {
         "success": False,
         "error": "Payment rejection: Santander - Payment rejected by the bank at step CREATE - Reason not returned by Santander",
+        "request_id": "QASF4568E48Q",
         "data": None,
     }
     assert mock_create.call_count == 1
@@ -220,7 +225,7 @@ def test_transfer_pix_payment_rejected_on_create(
 def test_transfer_pix_payment_rejected_on_confirm(
     client_instance: SantanderApiClient, mock_api
 ):
-    pix_id = "5A4SD6Q5W6Q68A"
+    pix_id = "b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e"
     value = Decimal("157.00")
     description = "Pagamento Teste"
     pix_key = "12345678909"
@@ -236,6 +241,7 @@ def test_transfer_pix_payment_rejected_on_confirm(
     assert transfer_result == {
         "success": False,
         "error": "Payment rejection: Santander - Payment rejected by the bank at step CONFIRM - Reason not returned by Santander",
+        "request_id": "b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e",
         "data": None,
     }
     assert mock_create.call_count == 1
@@ -245,7 +251,7 @@ def test_transfer_pix_payment_rejected_on_confirm(
 def test_transfer_pix_payment_with_beneficiary(
     client_instance: SantanderApiClient, mock_api
 ):
-    pix_id = "ASF5Q7Q879WQ"
+    pix_id = "9f8e7d6c-5b4a-4c3d-8e2f-1a0b9c8d7e6f"
     value = Decimal("59.99")
     description = "Pagamento Teste"
 
@@ -294,7 +300,7 @@ def test_transfer_pix_payment_with_beneficiary(
                 "number": "123456789",
             },
             "deductedValue": "0.00",
-            "id": "ASF5Q7Q879WQ",
+            "id": "9f8e7d6c-5b4a-4c3d-8e2f-1a0b9c8d7e6f",
             "nominalValue": "59.99",
             "obs": "payment mockado",
             "payer": {
@@ -304,7 +310,7 @@ def test_transfer_pix_payment_with_beneficiary(
             },
             "paymentValue": "59.99",
             "remittanceInformation": "informação da transferência",
-            "status": OrderStatus.PAYED,
+            "status": "PAYED",
             "tags": [],
             "totalValue": "59.99",
             "transaction": {
@@ -315,6 +321,7 @@ def test_transfer_pix_payment_with_beneficiary(
             },
             "workspaceId": "3870ba5d-d58e-4182-992f-454e5d0e08e2",
         },
+        "request_id": "9f8e7d6c-5b4a-4c3d-8e2f-1a0b9c8d7e6f",
         "error": "",
     }
     assert mock_create.call_count == 1
@@ -329,14 +336,14 @@ def test_transfer_pix_payment_with_beneficiary(
     }
     assert (
         confirm_payment_request_url
-        == "https://trust-sandbox.api.santander.com.br/management_payments_partners/v1/workspaces/8e33d56c-204f-461e-aebe-08baaab6479e/pix_payments/ASF5Q7Q879WQ"
+        == "https://trust-sandbox.api.santander.com.br/management_payments_partners/v1/workspaces/8e33d56c-204f-461e-aebe-08baaab6479e/pix_payments/9f8e7d6c-5b4a-4c3d-8e2f-1a0b9c8d7e6f"
     )
 
 
 def test_transfer_pix_payment_lazy_status_update(
     client_instance: SantanderApiClient, mock_api
 ):
-    pix_id = "12345"
+    pix_id = "c1a4f3e2-9b7d-4e5a-8c2e-3f1b2a4d5e6f"
     value = Decimal("130000.00")
     description = "Pagamento Teste"
     pix_key = "12345678909"
@@ -372,29 +379,30 @@ def test_transfer_pix_payment_lazy_status_update(
                 "number": "123456789",
             },
             "deductedValue": "0.00",
-            "dictCode": pix_key,
+            "dictCode": "12345678909",
             "dictCodeType": "CPF",
-            "id": pix_id,
-            "nominalValue": str(value),
+            "id": "c1a4f3e2-9b7d-4e5a-8c2e-3f1b2a4d5e6f",
+            "nominalValue": "130000.00",
             "obs": "payment mockado",
             "payer": {
                 "documentNumber": "20157935000193",
                 "documentType": "CPNJ",
                 "name": "John Doe SA",
             },
-            "paymentValue": str(value),
+            "paymentValue": "130000.00",
             "remittanceInformation": "informação da transferência",
-            "status": OrderStatus.PAYED,
+            "status": "PAYED",
             "tags": [],
-            "totalValue": str(value),
+            "totalValue": "130000.00",
             "transaction": {
                 "code": "13a654q",
                 "date": "2025-01-08T13:44:36Z",
                 "endToEnd": "a213e5q564as456f4as56f",
-                "value": str(value),
+                "value": "130000.00",
             },
             "workspaceId": "3870ba5d-d58e-4182-992f-454e5d0e08e2",
         },
+        "request_id": "c1a4f3e2-9b7d-4e5a-8c2e-3f1b2a4d5e6f",
         "error": "",
     }
     assert mock_create.call_count == 1

--- a/tests/test_pix_unit.py
+++ b/tests/test_pix_unit.py
@@ -97,6 +97,33 @@ def test_request_create_pix_payment_by_key(api_client, mock_sdk):
         mock_sdk.confirm.reset_mock()
 
 
+def test_request_create_pix_payment_by_passing_uuid(api_client, mock_sdk):
+    response = transfer_pix(
+        api_client,
+        "12345678909",
+        D("123"),
+        "Pagamento Teste",
+        tags=tags,
+        id="b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e",
+    )
+    assert response["success"] is True
+    mock_sdk.create.assert_called_with(
+        {
+            "id": "b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e",
+            "tags": tags,
+            "paymentValue": "123.00",
+            "remittanceInformation": "Pagamento Teste",
+            "dictCode": "12345678909",
+            "dictCodeType": "CPF",
+        }
+    )
+    mock_sdk.ready_to_pay.assert_called_once_with(create_pix_response)
+    confirm_payment_request_url = mock_sdk.confirm.calls[0].request.url
+    assert confirm_payment_request_url.contains(
+        "pix_payments/b8e2c7b8-2e8e-4e2c-8e6e-2e8e4e2c8e6e"
+    )
+
+
 def test_request_create_pix_payment_with_beneficiary(api_client, mock_sdk):
     response = transfer_pix(
         api_client, santander_beneciary_john, D("1248.33"), "Pagamento de teste", tags


### PR DESCRIPTION
- Add support for sending the unique PIX ID
- Return the PIX ID in both success and failure cases
- Improve test clarity
- Use ValueError to handle cases of value error
- [_payment_status_polling fix pyrigth](fix: resolve Pyright warning for possible undefined return)